### PR TITLE
Added generic MovingWindowAggregator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,9 @@ eclipse-bin/
 .settings/
 *.iml
 
+# VScode
+.vscode/
+.project
+
 # Mac
 .DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
+    <hamcrest-lib.version>1.3</hamcrest-lib.version>
     <apache.httpclient.version>4.5.3</apache.httpclient.version>
     <apache.httpcore.version>4.4.6</apache.httpcore.version>
 
@@ -367,6 +368,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest-lib.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,7 @@
     <!-- Test deps -->
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>
-    <hamcrest.version>2.0.0.0</hamcrest.version>
-    <hamcrest-lib.version>1.3</hamcrest-lib.version>
+    <hamcrest.version>1.3</hamcrest.version>
     <apache.httpclient.version>4.5.3</apache.httpclient.version>
     <apache.httpcore.version>4.4.6</apache.httpcore.version>
 
@@ -373,12 +372,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest-lib.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
       <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
@@ -1,0 +1,294 @@
+package com.arpnetworking.kairosdb.aggregators;
+
+import org.joda.time.Chronology;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeField;
+import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.GregorianChronology;
+import org.json.JSONException;
+import org.json.JSONWriter;
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.aggregator.AggregatedDataPointGroupWrapper;
+import org.kairosdb.core.annotation.FeatureComponent;
+import org.kairosdb.core.datastore.DataPointGroup;
+import org.kairosdb.core.datastore.TimeUnit;
+import org.kairosdb.core.aggregator.RangeAggregator;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+@FeatureComponent(name = "movingWindow", description = "Creates a moving window of datapoints")
+public class MovingWindowAggregator extends RangeAggregator {
+    protected long m_startTime = 0L;
+    protected DateTimeZone m_timeZone = DateTimeZone.UTC;
+    protected boolean m_alignSampling = false;
+
+    public MovingWindowAggregator() {
+
+    }
+
+    @Override
+    public DataPointGroup aggregate(DataPointGroup dataPointGroup) {
+        checkNotNull(dataPointGroup);
+
+        if (m_alignSampling)
+            m_startTime = alignRangeBoundary(m_startTime);
+        return new MovingWindowDataPointGroup(dataPointGroup);
+    }
+
+    /**
+     * For YEARS, MONTHS, WEEKS, DAYS: Computes the timestamp of the first
+     * millisecond of the day of the timestamp. For HOURS, Computes the timestamp of
+     * the first millisecond of the hour of the timestamp. For MINUTES, Computes the
+     * timestamp of the first millisecond of the minute of the timestamp. For
+     * SECONDS, Computes the timestamp of the first millisecond of the second of the
+     * timestamp. For MILLISECONDS, returns the timestamp
+     *
+     * @param timestamp
+     * @return
+     */
+    // @SuppressWarnings("fallthrough")
+    private long alignRangeBoundary(long timestamp) {
+        DateTime dt = new DateTime(timestamp, m_timeZone);
+        TimeUnit tu = m_sampling.getUnit();
+        switch (tu) {
+        case YEARS:
+            dt = dt.withDayOfYear(1).withMillisOfDay(0);
+            break;
+        case MONTHS:
+            dt = dt.withDayOfMonth(1).withMillisOfDay(0);
+            break;
+        case WEEKS:
+            dt = dt.withDayOfWeek(1).withMillisOfDay(0);
+            break;
+        case DAYS:
+        case HOURS:
+        case MINUTES:
+        case SECONDS:
+            dt = dt.withHourOfDay(0);
+            dt = dt.withMinuteOfHour(0);
+            dt = dt.withSecondOfMinute(0);
+        default:
+            dt = dt.withMillisOfSecond(0);
+            break;
+        }
+        return dt.getMillis();
+    }
+
+    @Override
+    public boolean canAggregate(String groupType) {
+        return true;
+    }
+
+    @Override
+    public String getAggregatedGroupType(String groupType) {
+        return groupType;
+    }
+
+    @Override
+    public void setStartTime(long startTime) {
+        m_startTime = startTime;
+        super.setStartTime(startTime);
+    }
+
+    @Override
+    public void setTimeZone(DateTimeZone timeZone) {
+        m_timeZone = timeZone;
+        super.setTimeZone(timeZone);
+    }
+
+    @Override
+    public void setAlignSampling(boolean alignSampling) {
+        m_alignSampling = alignSampling;
+        super.setAlignSampling(alignSampling);
+    }
+
+    private class MovingWindowDataPointGroup extends AggregatedDataPointGroupWrapper {
+        protected DateTimeField m_unitField;
+        protected ConcurrentSkipListMap<Long, DataPoint> m_dpBuffer;
+        protected Iterator<DataPoint> m_dpIterator = null;
+        protected long m_currentRangeTime;
+
+        MovingWindowDataPointGroup(DataPointGroup dataPointGroup) {
+            super(dataPointGroup);
+            m_dpBuffer = new ConcurrentSkipListMap<>();
+            m_dpIterator = m_dpBuffer.values().iterator();
+
+            Chronology chronology = GregorianChronology.getInstance(m_timeZone);
+
+            TimeUnit tu = m_sampling.getUnit();
+            switch (tu) {
+            case YEARS:
+                m_unitField = chronology.year();
+                break;
+            case MONTHS:
+                m_unitField = chronology.monthOfYear();
+                break;
+            case WEEKS:
+                m_unitField = chronology.weekOfWeekyear();
+                break;
+            case DAYS:
+                m_unitField = chronology.dayOfMonth();
+                break;
+            case HOURS:
+                m_unitField = chronology.hourOfDay();
+                break;
+            case MINUTES:
+                m_unitField = chronology.minuteOfHour();
+                break;
+            case SECONDS:
+                m_unitField = chronology.secondOfDay();
+                break;
+            default:
+                m_unitField = chronology.millisOfSecond();
+                break;
+            }
+        }
+
+        protected long getStartRange(long timestamp) {
+            long samplingValue = m_sampling.getValue();
+            long difference = m_unitField.getDifferenceAsLong(timestamp, m_startTime);
+            if (m_unitField.remainder(timestamp - m_startTime) > 0) {
+                difference += 1;
+            }
+            return m_unitField.add(m_startTime, difference + -1 * samplingValue);
+        }
+
+        protected long getEndRange(long timestamp) {
+            long difference = m_unitField.getDifferenceAsLong(timestamp, m_startTime);
+            return m_unitField.add(m_startTime, difference) - 1;
+        }
+
+        @Override
+        public DataPoint next() {
+            if (m_dpBuffer.isEmpty() || !m_dpIterator.hasNext()) {
+
+                // We calculate start and end ranges as the ranges may not be
+                // consecutive if data does not show up in each range.
+                long startRange; 
+
+                if (m_dpBuffer.isEmpty()) {
+                    // This is the first datapoint so front-load the sample window amount of data.
+                    startRange = m_startTime;
+                } else {
+                    startRange = getStartRange(currentDataPoint.getTimestamp());
+                }
+
+                long endRange = m_unitField.add(startRange, m_sampling.getValue());
+                m_currentRangeTime = endRange;
+
+                // Trim off any data that is too old
+                m_dpBuffer = new ConcurrentSkipListMap<>(m_dpBuffer.tailMap(startRange, false));
+
+                // Add data up until the end of the range
+                while (currentDataPoint != null && currentDataPoint.getTimestamp() <= endRange) {
+                    if (currentDataPoint.getTimestamp() > startRange) {
+                        m_dpBuffer.put(currentDataPoint.getTimestamp(), currentDataPoint);
+                    }
+                    if (hasNextInternal()) {
+                        currentDataPoint = nextInternal();
+                    }
+                }
+
+                m_dpIterator = m_dpBuffer.values().iterator();
+            }
+
+            return new DataPointWrapper(m_currentRangeTime, m_dpIterator.next());
+        }
+
+        @Override
+        public boolean hasNext() {
+            return m_dpIterator.hasNext() || super.hasNext();
+        }
+
+        /**
+         * Computes the data point time for the aggregated value. Different strategies
+         * could be added here such as datapoint time = range start time = range end
+         * time = range median = current datapoint time
+         *
+         * @return
+         */
+        private long getDataPointTime() {
+            long datapointTime = currentDataPoint.getTimestamp();
+            if (m_alignStartTime) {
+                datapointTime = getStartRange(datapointTime);
+            } else if (m_alignEndTime) {
+                datapointTime = getEndRange(datapointTime);
+            }
+            return datapointTime;
+        }
+    }
+
+    @Override
+    protected RangeSubAggregator getSubAggregator() {
+        return null;
+    }
+
+    protected static class DataPointWrapper implements DataPoint {
+        protected DataPoint m_wrappedDataPoint;
+        protected long m_timestamp;
+
+        DataPointWrapper(long timestamp, DataPoint dataPoint) {
+            m_timestamp = timestamp;
+            m_wrappedDataPoint = dataPoint;
+        }
+
+        @Override
+        public long getTimestamp() {
+            return m_timestamp;
+        }
+
+        @Override
+        public void writeValueToBuffer(DataOutput buffer) throws IOException {
+            m_wrappedDataPoint.writeValueToBuffer(buffer);
+        }
+
+        @Override
+        public void writeValueToJson(JSONWriter writer) throws JSONException {
+            m_wrappedDataPoint.writeValueToJson(writer);
+        }
+
+        @Override
+        public String getApiDataType() {
+            return m_wrappedDataPoint.getApiDataType();
+        }
+
+        @Override
+        public String getDataStoreDataType() {
+            return m_wrappedDataPoint.getDataStoreDataType();
+        }
+
+        @Override
+        public boolean isLong() {
+            return m_wrappedDataPoint.isLong();
+        }
+
+        @Override
+        public long getLongValue() {
+            return m_wrappedDataPoint.getLongValue();
+        }
+
+        @Override
+        public boolean isDouble() {
+            return m_wrappedDataPoint.isDouble();
+        }
+
+        @Override
+        public double getDoubleValue() {
+            return m_wrappedDataPoint.getDoubleValue();
+        }
+
+        @Override
+        public DataPointGroup getDataPointGroup() {
+            return m_wrappedDataPoint.getDataPointGroup();
+        }
+
+        @Override
+        public void setDataPointGroup(DataPointGroup dataPointGroup) {
+            m_wrappedDataPoint.setDataPointGroup(dataPointGroup);
+        }
+    }
+}

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
@@ -182,10 +182,9 @@ public class MovingWindowAggregator extends RangeAggregator {
         }
 
         protected long getEndRange(final long timestamp) {
-            final long difference = _unitField.getDifferenceAsLong(timestamp, _startTime);
             // Subract one millisecond off the resulting time, so the endRange doesn't overlap
             // with the next startRange
-            return _unitField.add(_startTime, difference) - 1;
+            return _unitField.add(getStartRange(timestamp), 1) - 1;
         }
 
         @Override
@@ -228,23 +227,6 @@ public class MovingWindowAggregator extends RangeAggregator {
         @Override
         public boolean hasNext() {
             return _dpIterator.hasNext() || super.hasNext();
-        }
-
-        /**
-         * Computes the data point time for the aggregated value. Different strategies
-         * could be added here such as datapoint time = range start time = range end
-         * time = range median = current datapoint time
-         *
-         * @return
-         */
-        private long getDataPointTime() {
-            long datapointTime = currentDataPoint.getTimestamp();
-            if (m_alignStartTime) {
-                datapointTime = getStartRange(datapointTime);
-            } else if (m_alignEndTime) {
-                datapointTime = getEndRange(datapointTime);
-            }
-            return datapointTime;
         }
     }
 

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
@@ -50,7 +50,7 @@ public class MovingWindowAggregator extends RangeAggregator {
      * @param timestamp
      * @return
      */
-    // @SuppressWarnings("fallthrough")
+    @SuppressWarnings("fallthrough")
     private long alignRangeBoundary(long timestamp) {
         DateTime dt = new DateTime(timestamp, m_timeZone);
         TimeUnit tu = m_sampling.getUnit();

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
@@ -66,8 +66,8 @@ public class MovingWindowAggregator extends RangeAggregator {
      * SECONDS, Computes the timestamp of the first millisecond of the second of the
      * timestamp. For MILLISECONDS, returns the timestamp
      *
-     * @param timestamp
-     * @return
+     * @param timestamp Timestamp in milliseconds to use as a basis for range alignment
+     * @return timestamp aligned to the configured sampling unit
      */
     @SuppressWarnings("fallthrough")
     private long alignRangeBoundary(final long timestamp) {

--- a/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
+++ b/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
@@ -28,6 +28,7 @@ import org.kairosdb.core.datastore.TimeUnit;
 import org.kairosdb.testing.ListDataPointGroup;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -68,28 +69,28 @@ public class MovingWindowAggregatorTest {
             });
         }
 
-        final Iterator<Long> keyIter = dpCountMap.keySet().iterator();
-        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
-        Long nextTs = keyIter.next();
-        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 4, 1, 0, 0, utc)));
-        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(90L)); // 31 + 28 + 31
+        final Iterator<Map.Entry<Long, Long>> entryIter = dpCountMap.entrySet().iterator();
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+        Map.Entry<Long, Long> nextEntry = entryIter.next();
+        Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 4, 1, 0, 0, utc)));
+        Assert.assertThat(nextEntry.getValue(), Matchers.is(90L)); // 31 + 28 + 31
 
-        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
-        nextTs = keyIter.next();
-        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 5, 1, 0, 0, utc)));
-        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(89L)); // 28 + 31 + 30
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+        nextEntry = entryIter.next();
+        Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 5, 1, 0, 0, utc)));
+        Assert.assertThat(nextEntry.getValue(), Matchers.is(89L)); // 28 + 31 + 30
 
-        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
-        nextTs = keyIter.next();
-        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 6, 1, 0, 0, utc)));
-        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(92L)); // 31 + 30 + 31
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+        nextEntry = entryIter.next();
+        Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 6, 1, 0, 0, utc)));
+        Assert.assertThat(nextEntry.getValue(), Matchers.is(92L)); // 31 + 30 + 31
 
-        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
-        nextTs = keyIter.next();
-        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 7, 1, 0, 0, utc)));
-        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(91L)); // 30 + 31 + 30
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+        nextEntry = entryIter.next();
+        Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 7, 1, 0, 0, utc)));
+        Assert.assertThat(nextEntry.getValue(), Matchers.is(91L)); // 30 + 31 + 30
 
-        Assert.assertThat(keyIter.hasNext(), Matchers.is(false));
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(false));
     }
 
     @Test
@@ -123,12 +124,12 @@ public class MovingWindowAggregatorTest {
             });
         }
 
-        final Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+        final Iterator<Map.Entry<Long, Long>> entryIter = dpCountMap.entrySet().iterator();
         for (int i = 8; i <= 30; i++) {
-            Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
-            final Long nextTs = keyIter.next();
-            Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2018, 1, i, 0, 0, utc)));
-            Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(7L));
+            Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+            final Map.Entry<Long, Long> nextEntry = entryIter.next();
+            Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2018, 1, i, 0, 0, utc)));
+            Assert.assertThat(nextEntry.getValue(), Matchers.is(7L));
         }
     }
 
@@ -163,12 +164,12 @@ public class MovingWindowAggregatorTest {
             });
         }
 
-        final Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+        final Iterator<Map.Entry<Long, Long>> entryIter = dpCountMap.entrySet().iterator();
         for (int i = 8; i <= 29; i++) {
-            Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
-            final Long nextTs = keyIter.next();
-            Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2018, 1, i, 1, 1, utc)));
-            Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(7L));
+            Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+            final Map.Entry<Long, Long> nextEntry = entryIter.next();
+            Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2018, 1, i, 1, 1, utc)));
+            Assert.assertThat(nextEntry.getValue(), Matchers.is(7L));
         }
     }
 }

--- a/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
+++ b/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
@@ -1,7 +1,24 @@
+/**
+ * Copyright 2018 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.arpnetworking.kairosdb.aggregators;
 
+import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.Assert;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.aggregator.Sampling;
@@ -10,41 +27,93 @@ import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.core.datastore.TimeUnit;
 import org.kairosdb.testing.ListDataPointGroup;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Iterator;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+/**
+ * Test class for MovingWindowAggregator.
+ * 
+ * @author Gil Markham (gmarkham at dropbox dot com)
+ */
 public class MovingWindowAggregatorTest {
+    @Test
+    public void testMultipleMonthAggregationWithUTC() {
+        final ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
+        final DateTimeZone utc = DateTimeZone.UTC;
+
+        final DateTime startDate = new DateTime(2014, 1, 1, 1, 1, utc); // LEAP year
+        final DateTime stopDate = new DateTime(2014, 7, 1, 1, 1, utc);
+        for (DateTime iterationDT = startDate; iterationDT.isBefore(stopDate); iterationDT = iterationDT.plusDays(1)) {
+            dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        }
+
+        final MovingWindowAggregator agg = new MovingWindowAggregator();
+        agg.setSampling(new Sampling(3, TimeUnit.MONTHS));
+        agg.setAlignSampling(true);
+        agg.setStartTime(startDate.getMillis());
+
+        final DataPointGroup dpg = agg.aggregate(dpGroup);
+
+        final SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+
+        while (dpg.hasNext()) {
+            final DataPoint next = dpg.next();
+            dpCountMap.compute(next.getTimestamp(), (key, value) -> {
+                if (value == null) {
+                    return 1L;
+                } else {
+                    return value + 1;
+                }
+            });
+        }
+
+        final Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
+        Long nextTs = keyIter.next();
+        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 4, 1, 0, 0, utc)));
+        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(90L)); // 31 + 28 + 31
+
+        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
+        nextTs = keyIter.next();
+        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 5, 1, 0, 0, utc)));
+        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(89L)); // 28 + 31 + 30
+
+        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
+        nextTs = keyIter.next();
+        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 6, 1, 0, 0, utc)));
+        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(92L)); // 31 + 30 + 31
+
+        Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
+        nextTs = keyIter.next();
+        Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2014, 7, 1, 0, 0, utc)));
+        Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(91L)); // 30 + 31 + 30
+
+        Assert.assertThat(keyIter.hasNext(), Matchers.is(false));
+    }
 
     @Test
-	public void test_multipleMonthAggregationWithUTC()
-	{
-        ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
-		DateTimeZone utc = DateTimeZone.UTC;
+    public void testMultipleRolling7DayAggregationWithUTC() {
+        final ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
+        final DateTimeZone utc = DateTimeZone.UTC;
 
-		DateTime startDate = new DateTime(2014, 1, 1, 1, 1, utc); // LEAP year
-		DateTime stopDate = new DateTime(2014, 7, 1, 1, 1, utc);
-		for (DateTime iterationDT = startDate;
-		     iterationDT.isBefore(stopDate);
-		     iterationDT = iterationDT.plusDays(1))
-		{
-			dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        final DateTime startDate = new DateTime(2018, 1, 1, 1, 1, utc);
+        final DateTime stopDate = new DateTime(2018, 1, 30, 1, 1, utc);
+        for (DateTime iterationDT = startDate; iterationDT.isBefore(stopDate); iterationDT = iterationDT.plusDays(1)) {
+            dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
         }
-        
-		MovingWindowAggregator agg = new MovingWindowAggregator();
-		agg.setSampling(new Sampling(3, TimeUnit.MONTHS));
-		agg.setAlignSampling(true);
-		agg.setStartTime(startDate.getMillis());
 
-        DataPointGroup dpg = agg.aggregate(dpGroup);
-        
-        SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+        final MovingWindowAggregator agg = new MovingWindowAggregator();
+        agg.setSampling(new Sampling(7, TimeUnit.DAYS));
+        agg.setAlignSampling(true);
+        agg.setStartTime(startDate.getMillis());
 
-        while(dpg.hasNext()) {
-            DataPoint next = dpg.next();
+        final DataPointGroup dpg = agg.aggregate(dpGroup);
+
+        final SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+
+        while (dpg.hasNext()) {
+            final DataPoint next = dpg.next();
             dpCountMap.compute(next.getTimestamp(), (key, value) -> {
                 if (value == null) {
                     return 1L;
@@ -54,56 +123,37 @@ public class MovingWindowAggregatorTest {
             });
         }
 
-        Iterator<Long> keyIter = dpCountMap.keySet().iterator();
-        assertThat(keyIter.hasNext(), is(true));
-		Long nextTs = keyIter.next();
-		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 4, 1, 0, 0, utc)));
-		assertThat(dpCountMap.get(nextTs), is(90L)); // 31 + 28 + 31
-
-        assertThat(keyIter.hasNext(), is(true));
-		nextTs = keyIter.next();
-		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 5, 1, 0, 0, utc)));
-		assertThat(dpCountMap.get(nextTs), is(89L)); // 28 + 31 + 30
-
-        assertThat(keyIter.hasNext(), is(true));
-		nextTs = keyIter.next();
-		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 6, 1, 0, 0, utc)));
-		assertThat(dpCountMap.get(nextTs), is(92L)); // 31 + 30 + 31
-        
-        assertThat(keyIter.hasNext(), is(true));
-		nextTs = keyIter.next();
-		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 7, 1, 0, 0, utc)));
-		assertThat(dpCountMap.get(nextTs), is(91L)); // 30 + 31 + 30
-		
-		assertThat(keyIter.hasNext(), is(false));
-	}
-
-	@Test
-	public void test_multipleRolling7DayAggregationWithUTC()
-	{
-        ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
-		DateTimeZone utc = DateTimeZone.UTC;
-
-		DateTime startDate = new DateTime(2018, 1, 1, 1, 1, utc); 
-		DateTime stopDate = new DateTime(2018, 1, 30, 1, 1, utc);
-		for (DateTime iterationDT = startDate;
-		     iterationDT.isBefore(stopDate);
-		     iterationDT = iterationDT.plusDays(1))
-		{
-			dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        final Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+        for (int i = 8; i <= 30; i++) {
+            Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
+            final Long nextTs = keyIter.next();
+            Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2018, 1, i, 0, 0, utc)));
+            Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(7L));
         }
-        
-		MovingWindowAggregator agg = new MovingWindowAggregator();
-		agg.setSampling(new Sampling(7, TimeUnit.DAYS));
-		agg.setAlignSampling(true);
-		agg.setStartTime(startDate.getMillis());
+    }
 
-        DataPointGroup dpg = agg.aggregate(dpGroup);
-        
-        SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+    @Test
+    public void testMultipleUnalignedRolling7DayAggregationWithUTC() {
+        final ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
+        final DateTimeZone utc = DateTimeZone.UTC;
 
-        while(dpg.hasNext()) {
-            DataPoint next = dpg.next();
+        final DateTime startDate = new DateTime(2018, 1, 1, 1, 1, utc);
+        final DateTime stopDate = new DateTime(2018, 1, 30, 1, 1, utc);
+        for (DateTime iterationDT = startDate; iterationDT.isBefore(stopDate); iterationDT = iterationDT.plusDays(1)) {
+            dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        }
+
+        final MovingWindowAggregator agg = new MovingWindowAggregator();
+        agg.setSampling(new Sampling(7, TimeUnit.DAYS));
+        agg.setAlignSampling(false);
+        agg.setStartTime(startDate.getMillis());
+
+        final DataPointGroup dpg = agg.aggregate(dpGroup);
+
+        final SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+
+        while (dpg.hasNext()) {
+            final DataPoint next = dpg.next();
             dpCountMap.compute(next.getTimestamp(), (key, value) -> {
                 if (value == null) {
                     return 1L;
@@ -113,56 +163,12 @@ public class MovingWindowAggregatorTest {
             });
         }
 
-		Iterator<Long> keyIter = dpCountMap.keySet().iterator();
-		for (int i = 8; i <= 30; i++) {
-			assertThat(keyIter.hasNext(), is(true));
-			Long nextTs = keyIter.next();
-			assertThat(new DateTime(nextTs, utc), is(new DateTime(2018, 1, i, 0, 0, utc)));
-			assertThat(dpCountMap.get(nextTs), is(7L)); 
-		}
-	}
-
-	@Test
-	public void test_multipleUnalignedRolling7DayAggregationWithUTC()
-	{
-        ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
-		DateTimeZone utc = DateTimeZone.UTC;
-
-		DateTime startDate = new DateTime(2018, 1, 1, 1, 1, utc); 
-		DateTime stopDate = new DateTime(2018, 1, 30, 1, 1, utc);
-		for (DateTime iterationDT = startDate;
-		     iterationDT.isBefore(stopDate);
-		     iterationDT = iterationDT.plusDays(1))
-		{
-			dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        final Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+        for (int i = 8; i <= 29; i++) {
+            Assert.assertThat(keyIter.hasNext(), Matchers.is(true));
+            final Long nextTs = keyIter.next();
+            Assert.assertThat(new DateTime(nextTs, utc), Matchers.is(new DateTime(2018, 1, i, 1, 1, utc)));
+            Assert.assertThat(dpCountMap.get(nextTs), Matchers.is(7L));
         }
-        
-		MovingWindowAggregator agg = new MovingWindowAggregator();
-		agg.setSampling(new Sampling(7, TimeUnit.DAYS));
-		agg.setAlignSampling(false);
-		agg.setStartTime(startDate.getMillis());
-
-        DataPointGroup dpg = agg.aggregate(dpGroup);
-        
-        SortedMap<Long, Long> dpCountMap = new TreeMap<>();
-
-        while(dpg.hasNext()) {
-            DataPoint next = dpg.next();
-            dpCountMap.compute(next.getTimestamp(), (key, value) -> {
-                if (value == null) {
-                    return 1L;
-                } else {
-                    return value + 1;
-                }
-            });
-        }
-
-		Iterator<Long> keyIter = dpCountMap.keySet().iterator();
-		for (int i = 8; i <= 29; i++) {
-			assertThat(keyIter.hasNext(), is(true));
-			Long nextTs = keyIter.next();
-			assertThat(new DateTime(nextTs, utc), is(new DateTime(2018, 1, i, 1, 1, utc)));
-			assertThat(dpCountMap.get(nextTs), is(7L)); 
-		}
-	}
+    }
 }

--- a/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
+++ b/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
@@ -1,0 +1,168 @@
+package com.arpnetworking.kairosdb.aggregators;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.aggregator.Sampling;
+import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datastore.DataPointGroup;
+import org.kairosdb.core.datastore.TimeUnit;
+import org.kairosdb.testing.ListDataPointGroup;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Iterator;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class MovingWindowAggregatorTest {
+
+    @Test
+	public void test_multipleMonthAggregationWithUTC()
+	{
+        ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
+		DateTimeZone utc = DateTimeZone.UTC;
+
+		DateTime startDate = new DateTime(2014, 1, 1, 1, 1, utc); // LEAP year
+		DateTime stopDate = new DateTime(2014, 7, 1, 1, 1, utc);
+		for (DateTime iterationDT = startDate;
+		     iterationDT.isBefore(stopDate);
+		     iterationDT = iterationDT.plusDays(1))
+		{
+			dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        }
+        
+		MovingWindowAggregator agg = new MovingWindowAggregator();
+		agg.setSampling(new Sampling(3, TimeUnit.MONTHS));
+		agg.setAlignSampling(true);
+		agg.setStartTime(startDate.getMillis());
+
+        DataPointGroup dpg = agg.aggregate(dpGroup);
+        
+        SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+
+        while(dpg.hasNext()) {
+            DataPoint next = dpg.next();
+            dpCountMap.compute(next.getTimestamp(), (key, value) -> {
+                if (value == null) {
+                    return 1L;
+                } else {
+                    return value + 1;
+                }
+            });
+        }
+
+        Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+        assertThat(keyIter.hasNext(), is(true));
+		Long nextTs = keyIter.next();
+		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 4, 1, 0, 0, utc)));
+		assertThat(dpCountMap.get(nextTs), is(90L)); // 31 + 28 + 31
+
+        assertThat(keyIter.hasNext(), is(true));
+		nextTs = keyIter.next();
+		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 5, 1, 0, 0, utc)));
+		assertThat(dpCountMap.get(nextTs), is(89L)); // 28 + 31 + 30
+
+        assertThat(keyIter.hasNext(), is(true));
+		nextTs = keyIter.next();
+		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 6, 1, 0, 0, utc)));
+		assertThat(dpCountMap.get(nextTs), is(92L)); // 31 + 30 + 31
+        
+        assertThat(keyIter.hasNext(), is(true));
+		nextTs = keyIter.next();
+		assertThat(new DateTime(nextTs, utc), is(new DateTime(2014, 7, 1, 0, 0, utc)));
+		assertThat(dpCountMap.get(nextTs), is(91L)); // 30 + 31 + 30
+		
+		assertThat(keyIter.hasNext(), is(false));
+	}
+
+	@Test
+	public void test_multipleRolling7DayAggregationWithUTC()
+	{
+        ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
+		DateTimeZone utc = DateTimeZone.UTC;
+
+		DateTime startDate = new DateTime(2018, 1, 1, 1, 1, utc); 
+		DateTime stopDate = new DateTime(2018, 1, 30, 1, 1, utc);
+		for (DateTime iterationDT = startDate;
+		     iterationDT.isBefore(stopDate);
+		     iterationDT = iterationDT.plusDays(1))
+		{
+			dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        }
+        
+		MovingWindowAggregator agg = new MovingWindowAggregator();
+		agg.setSampling(new Sampling(7, TimeUnit.DAYS));
+		agg.setAlignSampling(true);
+		agg.setStartTime(startDate.getMillis());
+
+        DataPointGroup dpg = agg.aggregate(dpGroup);
+        
+        SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+
+        while(dpg.hasNext()) {
+            DataPoint next = dpg.next();
+            dpCountMap.compute(next.getTimestamp(), (key, value) -> {
+                if (value == null) {
+                    return 1L;
+                } else {
+                    return value + 1;
+                }
+            });
+        }
+
+		Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+		for (int i = 8; i <= 30; i++) {
+			assertThat(keyIter.hasNext(), is(true));
+			Long nextTs = keyIter.next();
+			assertThat(new DateTime(nextTs, utc), is(new DateTime(2018, 1, i, 0, 0, utc)));
+			assertThat(dpCountMap.get(nextTs), is(7L)); 
+		}
+	}
+
+	@Test
+	public void test_multipleUnalignedRolling7DayAggregationWithUTC()
+	{
+        ListDataPointGroup dpGroup = new ListDataPointGroup("range_group");
+		DateTimeZone utc = DateTimeZone.UTC;
+
+		DateTime startDate = new DateTime(2018, 1, 1, 1, 1, utc); 
+		DateTime stopDate = new DateTime(2018, 1, 30, 1, 1, utc);
+		for (DateTime iterationDT = startDate;
+		     iterationDT.isBefore(stopDate);
+		     iterationDT = iterationDT.plusDays(1))
+		{
+			dpGroup.addDataPoint(new LongDataPoint(iterationDT.getMillis(), 1));
+        }
+        
+		MovingWindowAggregator agg = new MovingWindowAggregator();
+		agg.setSampling(new Sampling(7, TimeUnit.DAYS));
+		agg.setAlignSampling(false);
+		agg.setStartTime(startDate.getMillis());
+
+        DataPointGroup dpg = agg.aggregate(dpGroup);
+        
+        SortedMap<Long, Long> dpCountMap = new TreeMap<>();
+
+        while(dpg.hasNext()) {
+            DataPoint next = dpg.next();
+            dpCountMap.compute(next.getTimestamp(), (key, value) -> {
+                if (value == null) {
+                    return 1L;
+                } else {
+                    return value + 1;
+                }
+            });
+        }
+
+		Iterator<Long> keyIter = dpCountMap.keySet().iterator();
+		for (int i = 8; i <= 29; i++) {
+			assertThat(keyIter.hasNext(), is(true));
+			Long nextTs = keyIter.next();
+			assertThat(new DateTime(nextTs, utc), is(new DateTime(2018, 1, i, 1, 1, utc)));
+			assertThat(dpCountMap.get(nextTs), is(7L)); 
+		}
+	}
+}

--- a/src/test/java/org/kairosdb/testing/ListDataPointGroup.java
+++ b/src/test/java/org/kairosdb/testing/ListDataPointGroup.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 KairosDB Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.kairosdb.testing;
+
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.datastore.AbstractDataPointGroup;
+import org.kairosdb.core.datastore.Order;
+
+import java.util.*;
+
+public class ListDataPointGroup extends AbstractDataPointGroup
+{
+	private List<DataPoint> dataPoints = new ArrayList<DataPoint>();
+	private Iterator<DataPoint> iterator;
+
+	public ListDataPointGroup(String name)
+	{
+		super(name);
+	}
+
+	@Override
+	public void close()
+	{
+	}
+
+	public void addDataPoint(DataPoint dataPoint)
+	{
+		dataPoints.add(dataPoint);
+	}
+
+	@Override
+	public boolean hasNext()
+	{
+		if (iterator == null)
+			iterator = dataPoints.iterator();
+
+		return (iterator.hasNext());
+	}
+
+	@Override
+	public DataPoint next()
+	{
+		if (iterator == null)
+			iterator = dataPoints.iterator();
+
+		return (iterator.next());
+	}
+
+	public void sort(Order order)
+	{
+		if (order == Order.ASC)
+			Collections.sort(dataPoints, new DataPointComparator());
+		else
+			Collections.sort(dataPoints, Collections.reverseOrder(new DataPointComparator()));
+
+	}
+
+	private class DataPointComparator implements Comparator<DataPoint>
+	{
+		@Override
+		public int compare(DataPoint point1, DataPoint point2)
+		{
+			long ret = point1.getTimestamp() - point2.getTimestamp();
+
+			if (ret == 0L)
+				ret = Double.compare(point1.getDoubleValue(), point2.getDoubleValue());
+
+			if (ret == 0L)
+			{  //Simple hack to break a tie.
+				ret = System.identityHashCode(point1) - System.identityHashCode(point2);
+			}
+
+			return (ret < 0L ? -1 : 1);
+		}
+	}
+}

--- a/src/test/java/org/kairosdb/testing/ListDataPointGroup.java
+++ b/src/test/java/org/kairosdb/testing/ListDataPointGroup.java
@@ -1,17 +1,17 @@
-/*
+/**
  * Copyright 2016 KairosDB Authors
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.kairosdb.testing;
 
@@ -19,71 +19,89 @@ import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.datastore.AbstractDataPointGroup;
 import org.kairosdb.core.datastore.Order;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
 
-public class ListDataPointGroup extends AbstractDataPointGroup
-{
-	private List<DataPoint> dataPoints = new ArrayList<DataPoint>();
-	private Iterator<DataPoint> iterator;
+/**
+ * DataPoint group for a list of datapoints for use in tests.
+ * 
+ * @author KairosDB Authors
+ */
+public class ListDataPointGroup extends AbstractDataPointGroup {
+    private List<DataPoint> _dataPoints = new ArrayList<DataPoint>();
+    private Iterator<DataPoint> _iterator;
 
-	public ListDataPointGroup(String name)
-	{
-		super(name);
-	}
+    /**
+     * Constructor that delagates name to AbstractDataPointGroup.
+     * 
+     * @param name Name of data point group
+     */
+    public ListDataPointGroup(final String name) {
+        super(name);
+    }
 
-	@Override
-	public void close()
-	{
-	}
+    @Override
+    public void close() {
+    }
 
-	public void addDataPoint(DataPoint dataPoint)
-	{
-		dataPoints.add(dataPoint);
-	}
+    /**
+     * Adds a datapoint to this datapoint group.
+     * 
+     * @param dataPoint DataPoint to add
+     */
+    public void addDataPoint(final DataPoint dataPoint) {
+        _dataPoints.add(dataPoint);
+    }
 
-	@Override
-	public boolean hasNext()
-	{
-		if (iterator == null)
-			iterator = dataPoints.iterator();
+    @Override
+    public boolean hasNext() {
+        if (_iterator == null) {
+            _iterator = _dataPoints.iterator();
+        }
 
-		return (iterator.hasNext());
-	}
+        return _iterator.hasNext();
+    }
 
-	@Override
-	public DataPoint next()
-	{
-		if (iterator == null)
-			iterator = dataPoints.iterator();
+    @Override
+    public DataPoint next() {
+        if (_iterator == null) {
+            _iterator = _dataPoints.iterator();
+        }
 
-		return (iterator.next());
-	}
+        return _iterator.next();
+    }
 
-	public void sort(Order order)
-	{
-		if (order == Order.ASC)
-			Collections.sort(dataPoints, new DataPointComparator());
-		else
-			Collections.sort(dataPoints, Collections.reverseOrder(new DataPointComparator()));
+    /**
+     * In-place sort of the datapoints in this datapoint group by value.
+     * 
+     * @param order Order in witch to sort the datapoints
+     */
+    public void sort(final Order order) {
+        if (order == Order.ASC) {
+            Collections.sort(_dataPoints, new DataPointComparator());
+        } else {
+            Collections.sort(_dataPoints, Collections.reverseOrder(new DataPointComparator()));
+        }
 
-	}
+    }
 
-	private class DataPointComparator implements Comparator<DataPoint>
-	{
-		@Override
-		public int compare(DataPoint point1, DataPoint point2)
-		{
-			long ret = point1.getTimestamp() - point2.getTimestamp();
+    private class DataPointComparator implements Comparator<DataPoint> {
+        @Override
+        public int compare(final DataPoint point1, final DataPoint point2) {
+            long ret = point1.getTimestamp() - point2.getTimestamp();
 
-			if (ret == 0L)
-				ret = Double.compare(point1.getDoubleValue(), point2.getDoubleValue());
+            if (ret == 0L) {
+                ret = Double.compare(point1.getDoubleValue(), point2.getDoubleValue());
+            }
 
-			if (ret == 0L)
-			{  //Simple hack to break a tie.
-				ret = System.identityHashCode(point1) - System.identityHashCode(point2);
-			}
+            if (ret == 0L) { // Simple hack to break a tie.
+                ret = System.identityHashCode(point1) - System.identityHashCode(point2);
+            }
 
-			return (ret < 0L ? -1 : 1);
-		}
-	}
+            return ret < 0L ? -1 : 1;
+        }
+    }
 }

--- a/src/test/java/org/kairosdb/testing/ListDataPointGroup.java
+++ b/src/test/java/org/kairosdb/testing/ListDataPointGroup.java
@@ -19,6 +19,7 @@ import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.datastore.AbstractDataPointGroup;
 import org.kairosdb.core.datastore.Order;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -88,7 +89,10 @@ public class ListDataPointGroup extends AbstractDataPointGroup {
 
     }
 
-    private class DataPointComparator implements Comparator<DataPoint> {
+    private static class DataPointComparator implements Comparator<DataPoint>, Serializable {
+
+        private static final long serialVersionUID = -3986265694230498036L;
+
         @Override
         public int compare(final DataPoint point1, final DataPoint point2) {
             long ret = point1.getTimestamp() - point2.getTimestamp();


### PR DESCRIPTION
 The MovingWindowAggregator rewrites timestamps for datapoints in a backward looking range of time so that downstream aggregators can re-aggregate them as if they came from the same point in time.  This allows for calculation of data over a moving/rolling window of time.