### PR TITLE
Fixed issues with movingWindow aggregator and histogram data, added query pre processor.

### DIFF
--- a/src/main/java/com/arpnetworking/kairosdb/HistogramDataPoint.java
+++ b/src/main/java/com/arpnetworking/kairosdb/HistogramDataPoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 SmartSheet.com
+ * Copyright 2018 Dropbox Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,8 @@
  */
 package com.arpnetworking.kairosdb;
 
-import org.json.JSONException;
-import org.json.JSONWriter;
-import org.kairosdb.core.datapoints.DataPointHelper;
+import org.kairosdb.core.DataPoint;
 
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.Map;
 import java.util.TreeMap;
 
 /**
@@ -29,121 +24,34 @@ import java.util.TreeMap;
  *
  * @author Brandon Arp (brandon dot arp at smartsheet dot com)
  */
-public class HistogramDataPoint extends DataPointHelper {
-    private static final String API_TYPE = "histogram";
-    private final int _precision;
-    private final TreeMap<Double, Integer> _map;
-    private final double _min;
-    private final double _max;
-    private final double _mean;
-    private final double _sum;
+public interface HistogramDataPoint extends DataPoint {
+    /**
+     * Getter for sample count contained in this HistogramDataPoint.
+     * @return datapoint sample count
+     */
+    int getSampleCount();
 
     /**
-     * Public constructor.
-     *
-     * @param timestamp the timestamp.
-     * @param precision bucket precision, in bits
-     * @param map the bins with values
-     * @param min the minimum value in the histogram
-     * @param max the maximum value in the histogram
-     * @param mean the mean value in the histogram
-     * @param sum the sum of all the values in the histogram
+     * Getter for the sum of all samples contained in this HistogramDataPoint.
+     * @return sum of histogram samples
      */
-    public HistogramDataPoint(final long timestamp, final int precision, final TreeMap<Double, Integer> map, final double min,
-                              final double max, final double mean, final double sum) {
-        super(timestamp);
-        _precision = precision;
-        _map = map;
-        _min = min;
-        _max = max;
-        _mean = mean;
-        _sum = sum;
-    }
-
-    @Override
-    public void writeValueToBuffer(final DataOutput buffer) throws IOException {
-        buffer.writeInt(_map.size());
-        for (Map.Entry<Double, Integer> entry : _map.entrySet()) {
-            buffer.writeDouble(entry.getKey());
-            buffer.writeInt(entry.getValue());
-        }
-        buffer.writeDouble(_min);
-        buffer.writeDouble(_max);
-        buffer.writeDouble(_mean);
-        buffer.writeDouble(_sum);
-    }
-
-    @Override
-    public void writeValueToJson(final JSONWriter writer) throws JSONException {
-        writer.object().key("bins");
-        writer.object();
-        for (Map.Entry<Double, Integer> entry : _map.entrySet()) {
-            writer.key(entry.getKey().toString()).value(entry.getValue());
-        }
-        writer.endObject();
-        writer.key("min").value(_min);
-        writer.key("max").value(_max);
-        writer.key("mean").value(_mean);
-        writer.key("sum").value(_sum);
-        writer.endObject();
-    }
-
-    @Override
-    public String getApiDataType() {
-        return API_TYPE;
-    }
-
-    @Override
-    public String getDataStoreDataType() {
-        return HistogramDataPointFactory.DST;
-    }
-
-    @Override
-    public boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public long getLongValue() {
-        return 0;
-    }
-
-    @Override
-    public boolean isDouble() {
-        return false;
-    }
-
-    @Override
-    public double getDoubleValue() {
-        return 0;
-    }
+    double getSum();
 
     /**
-     * Gets the number of samples in the bins.
-     *
-     * @return the number of samples
+     * Getter for the min value of the samples contained in this HistogramDataPoint.
+     * @return min of histogram samples
      */
-    public int getSampleCount() {
-        int count = 0;
-        for (Integer binSamples : _map.values()) {
-            count += binSamples;
-        }
-        return count;
-    }
+    double getMin();
 
-    public double getSum() {
-        return _sum;
-    }
+    /**
+     * Getter for the max value of the samples contained in this HistogramDataPoint.
+     * @return max of histogram samples
+     */
+    double getMax();
 
-    public double getMin() {
-        return _min;
-    }
-
-    public double getMax() {
-        return _max;
-    }
-
-    public TreeMap<Double, Integer> getMap() {
-        return _map;
-    }
+    /**
+     * Getter for the map of lower bucket value to sample count contained in this HistogramDataPoint.
+     * @return map of histogram buckets
+     */
+    TreeMap<Double, Integer> getMap();
 }

--- a/src/main/java/com/arpnetworking/kairosdb/HistogramDataPoint.java
+++ b/src/main/java/com/arpnetworking/kairosdb/HistogramDataPoint.java
@@ -17,12 +17,12 @@ package com.arpnetworking.kairosdb;
 
 import org.kairosdb.core.DataPoint;
 
-import java.util.TreeMap;
+import java.util.NavigableMap;
 
 /**
  * DataPoint that represents a Histogram.
  *
- * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ * @author Gil Markham (gmarkham at dropbox dot com)
  */
 public interface HistogramDataPoint extends DataPoint {
     /**
@@ -53,5 +53,5 @@ public interface HistogramDataPoint extends DataPoint {
      * Getter for the map of lower bucket value to sample count contained in this HistogramDataPoint.
      * @return map of histogram buckets
      */
-    TreeMap<Double, Integer> getMap();
+    NavigableMap<Double, Integer> getMap();
 }

--- a/src/main/java/com/arpnetworking/kairosdb/HistogramDataPointFactory.java
+++ b/src/main/java/com/arpnetworking/kairosdb/HistogramDataPointFactory.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Factory that creates {@link HistogramDataPoint}.
+ * Factory that creates {@link HistogramDataPointImpl}.
  *
  * @author Brandon Arp (brandon dot arp at smartsheet dot com)
  */
@@ -72,7 +72,7 @@ public class HistogramDataPointFactory implements DataPointFactory{
             binValues.put(Double.parseDouble(entry.getKey()), entry.getValue().getAsInt());
         }
 
-        return new HistogramDataPoint(timestamp, 7, binValues, min, max, mean, sum);
+        return new HistogramDataPointImpl(timestamp, 7, binValues, min, max, mean, sum);
     }
 
     @Override
@@ -88,6 +88,6 @@ public class HistogramDataPointFactory implements DataPointFactory{
         final double mean = buffer.readDouble();
         final double sum = buffer.readDouble();
 
-        return new HistogramDataPoint(timestamp, 7, bins, min, max, mean, sum);
+        return new HistogramDataPointImpl(timestamp, 7, bins, min, max, mean, sum);
     }
 }

--- a/src/main/java/com/arpnetworking/kairosdb/HistogramDataPointImpl.java
+++ b/src/main/java/com/arpnetworking/kairosdb/HistogramDataPointImpl.java
@@ -49,8 +49,14 @@ public class HistogramDataPointImpl extends DataPointHelper implements Histogram
      * @param mean the mean value in the histogram
      * @param sum the sum of all the values in the histogram
      */
-    public HistogramDataPointImpl(final long timestamp, final int precision, final TreeMap<Double, Integer> map, final double min,
-                                  final double max, final double mean, final double sum) {
+    public HistogramDataPointImpl(
+            final long timestamp,
+            final int precision,
+            final TreeMap<Double, Integer> map,
+            final double min,
+            final double max,
+            final double mean,
+            final double sum) {
         super(timestamp);
         _precision = precision;
         _map = map;

--- a/src/main/java/com/arpnetworking/kairosdb/HistogramDataPointImpl.java
+++ b/src/main/java/com/arpnetworking/kairosdb/HistogramDataPointImpl.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2017 SmartSheet.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.kairosdb;
+
+import org.json.JSONException;
+import org.json.JSONWriter;
+import org.kairosdb.core.datapoints.DataPointHelper;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * DataPoint that represents a Histogram.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ */
+public class HistogramDataPointImpl extends DataPointHelper implements HistogramDataPoint {
+    private static final String API_TYPE = "histogram";
+    private final int _precision;
+    private final TreeMap<Double, Integer> _map;
+    private final double _min;
+    private final double _max;
+    private final double _mean;
+    private final double _sum;
+
+    /**
+     * Public constructor.
+     *
+     * @param timestamp the timestamp.
+     * @param precision bucket precision, in bits
+     * @param map the bins with values
+     * @param min the minimum value in the histogram
+     * @param max the maximum value in the histogram
+     * @param mean the mean value in the histogram
+     * @param sum the sum of all the values in the histogram
+     */
+    public HistogramDataPointImpl(final long timestamp, final int precision, final TreeMap<Double, Integer> map, final double min,
+                                  final double max, final double mean, final double sum) {
+        super(timestamp);
+        _precision = precision;
+        _map = map;
+        _min = min;
+        _max = max;
+        _mean = mean;
+        _sum = sum;
+    }
+
+    @Override
+    public void writeValueToBuffer(final DataOutput buffer) throws IOException {
+        buffer.writeInt(_map.size());
+        for (Map.Entry<Double, Integer> entry : _map.entrySet()) {
+            buffer.writeDouble(entry.getKey());
+            buffer.writeInt(entry.getValue());
+        }
+        buffer.writeDouble(_min);
+        buffer.writeDouble(_max);
+        buffer.writeDouble(_mean);
+        buffer.writeDouble(_sum);
+    }
+
+    @Override
+    public void writeValueToJson(final JSONWriter writer) throws JSONException {
+        writer.object().key("bins");
+        writer.object();
+        for (Map.Entry<Double, Integer> entry : _map.entrySet()) {
+            writer.key(entry.getKey().toString()).value(entry.getValue());
+        }
+        writer.endObject();
+        writer.key("min").value(_min);
+        writer.key("max").value(_max);
+        writer.key("mean").value(_mean);
+        writer.key("sum").value(_sum);
+        writer.endObject();
+    }
+
+    @Override
+    public String getApiDataType() {
+        return API_TYPE;
+    }
+
+    @Override
+    public String getDataStoreDataType() {
+        return HistogramDataPointFactory.DST;
+    }
+
+    @Override
+    public boolean isLong() {
+        return false;
+    }
+
+    @Override
+    public long getLongValue() {
+        return 0;
+    }
+
+    @Override
+    public boolean isDouble() {
+        return false;
+    }
+
+    @Override
+    public double getDoubleValue() {
+        return 0;
+    }
+
+    /**
+     * Gets the number of samples in the bins.
+     *
+     * @return the number of samples
+     */
+    @Override
+    public int getSampleCount() {
+        int count = 0;
+        for (Integer binSamples : _map.values()) {
+            count += binSamples;
+        }
+        return count;
+    }
+
+    @Override
+    public double getSum() {
+        return _sum;
+    }
+
+    @Override
+    public double getMin() {
+        return _min;
+    }
+
+    @Override
+    public double getMax() {
+        return _max;
+    }
+
+    @Override
+    public TreeMap<Double, Integer> getMap() {
+        return _map;
+    }
+}

--- a/src/main/java/com/arpnetworking/kairosdb/HistogramModule.java
+++ b/src/main/java/com/arpnetworking/kairosdb/HistogramModule.java
@@ -31,6 +31,8 @@ import com.arpnetworking.kairosdb.aggregators.HistogramMinAggregator;
 import com.arpnetworking.kairosdb.aggregators.HistogramPercentileAggregator;
 import com.arpnetworking.kairosdb.aggregators.HistogramStdDevAggregator;
 import com.arpnetworking.kairosdb.aggregators.HistogramSumAggregator;
+import com.arpnetworking.kairosdb.aggregators.MovingWindowAggregator;
+import com.arpnetworking.kairosdb.processors.MovingWindowQueryPreProcessor;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -86,6 +88,9 @@ public class HistogramModule extends AbstractModule {
 
         bind(DelegatingStdDevAggregator.class);
         bind(HistogramStdDevAggregator.class);
+
+        bind(MovingWindowAggregator.class);
+        bind(MovingWindowQueryPreProcessor.class);
     }
 
     @Provides

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/HistogramMergeAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/HistogramMergeAggregator.java
@@ -17,6 +17,7 @@ package com.arpnetworking.kairosdb.aggregators;
 
 import com.arpnetworking.kairosdb.HistogramDataPoint;
 import com.arpnetworking.kairosdb.HistogramDataPointFactory;
+import com.arpnetworking.kairosdb.HistogramDataPointImpl;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.kairosdb.core.DataPoint;
@@ -87,7 +88,7 @@ public final class HistogramMergeAggregator extends RangeAggregator {
 
             final double mean = sum / count;
 
-            return Collections.singletonList(new HistogramDataPoint(returnTime, 7, merged, min, max, mean, sum));
+            return Collections.singletonList(new HistogramDataPointImpl(returnTime, 7, merged, min, max, mean, sum));
         }
     }
 }

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/HistogramStdDevAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/HistogramStdDevAggregator.java
@@ -27,7 +27,7 @@ import org.kairosdb.core.exception.KairosDBException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.NavigableMap;
 
 /**
  * Aggregator that computes the standard deviation value of histograms.
@@ -77,7 +77,7 @@ public class HistogramStdDevAggregator extends RangeAggregator {
                 final DataPoint dp = dataPointRange.next();
                 if (dp instanceof HistogramDataPoint) {
                     final HistogramDataPoint hist = (HistogramDataPoint) dp;
-                    final TreeMap<Double, Integer> map = hist.getMap();
+                    final NavigableMap<Double, Integer> map = hist.getMap();
                     if (map != null) {
                         for (Map.Entry<Double, Integer> entry : map.entrySet()) {
                             final int n = entry.getValue();

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
@@ -15,7 +15,9 @@
  */
 package com.arpnetworking.kairosdb.aggregators;
 
+import com.arpnetworking.kairosdb.HistogramDataPoint;
 import com.google.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeField;
@@ -33,7 +35,9 @@ import org.kairosdb.core.datastore.TimeUnit;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Aggregator that takes a window of datapoints and emits them to downstream aggregators as if they came from the
@@ -44,9 +48,9 @@ import java.util.concurrent.ConcurrentSkipListMap;
  */
 @FeatureComponent(name = "movingWindow", description = "Creates a moving window of datapoints")
 public class MovingWindowAggregator extends RangeAggregator {
-    protected long _startTime = 0L;
-    protected DateTimeZone _timeZone = DateTimeZone.UTC;
-    protected boolean _alignSampling = false;
+    private long _startTime = 0L;
+    private DateTimeZone _timeZone = DateTimeZone.UTC;
+    private boolean _alignSampling = false;
 
     @Override
     public DataPointGroup aggregate(final DataPointGroup dataPointGroup) {
@@ -59,42 +63,18 @@ public class MovingWindowAggregator extends RangeAggregator {
     }
 
     /**
-     * For YEARS, MONTHS, WEEKS, DAYS: Computes the timestamp of the first
-     * millisecond of the day of the timestamp. For HOURS, Computes the timestamp of
-     * the first millisecond of the hour of the timestamp. For MINUTES, Computes the
-     * timestamp of the first millisecond of the minute of the timestamp. For
-     * SECONDS, Computes the timestamp of the first millisecond of the second of the
-     * timestamp. For MILLISECONDS, returns the timestamp
+     * Calculates the beginning of a window for the provided startTime given the sampling and
+     * alignment parameters of this aggregator.
      *
-     * @param timestamp Timestamp in milliseconds to use as a basis for range alignment
-     * @return timestamp aligned to the configured sampling unit
+     * @param startTime Time to use for calculating the window start
+     * @return The window start time for the provided startTime
      */
-    @SuppressWarnings("fallthrough")
-    private long alignRangeBoundary(final long timestamp) {
-        DateTime dt = new DateTime(timestamp, _timeZone);
-        final TimeUnit tu = m_sampling.getUnit();
-        switch (tu) {
-        case YEARS:
-            dt = dt.withDayOfYear(1).withMillisOfDay(0);
-            break;
-        case MONTHS:
-            dt = dt.withDayOfMonth(1).withMillisOfDay(0);
-            break;
-        case WEEKS:
-            dt = dt.withDayOfWeek(1).withMillisOfDay(0);
-            break;
-        case DAYS:
-        case HOURS:
-        case MINUTES:
-        case SECONDS:
-            dt = dt.withHourOfDay(0);
-            dt = dt.withMinuteOfHour(0);
-            dt = dt.withSecondOfMinute(0);
-        default:
-            dt = dt.withMillisOfSecond(0);
-            break;
+    public long calculateEarliestStartTime(final long startTime) {
+        long tmpStartTime = startTime;
+        if (_alignSampling) {
+           tmpStartTime = alignRangeBoundary(tmpStartTime);
         }
-        return dt.getMillis();
+        return timeUnitToTimeField(m_sampling.getUnit()).add(tmpStartTime, -1 * m_sampling.getValue());
     }
 
     @Override
@@ -130,46 +110,86 @@ public class MovingWindowAggregator extends RangeAggregator {
         return null;
     }
 
+    /**
+     * For YEARS, MONTHS, WEEKS, DAYS: Computes the timestamp of the first
+     * millisecond of the day of the timestamp. For HOURS, Computes the timestamp of
+     * the first millisecond of the hour of the timestamp. For MINUTES, Computes the
+     * timestamp of the first millisecond of the minute of the timestamp. For
+     * SECONDS, Computes the timestamp of the first millisecond of the second of the
+     * timestamp. For MILLISECONDS, returns the timestamp
+     *
+     * @param timestamp Timestamp in milliseconds to use as a basis for range alignment
+     * @return timestamp aligned to the configured sampling unit
+     */
+    @SuppressWarnings("fallthrough")
+    @SuppressFBWarnings("SF_SWITCH_FALLTHROUGH")
+    private long alignRangeBoundary(final long timestamp) {
+        DateTime dt = new DateTime(timestamp, _timeZone);
+        final TimeUnit tu = m_sampling.getUnit();
+        switch (tu) {
+            case YEARS:
+                dt = dt.withDayOfYear(1).withMillisOfDay(0);
+                break;
+            case MONTHS:
+                dt = dt.withDayOfMonth(1).withMillisOfDay(0);
+                break;
+            case WEEKS:
+                dt = dt.withDayOfWeek(1).withMillisOfDay(0);
+                break;
+            case DAYS:
+                dt = dt.withHourOfDay(0);
+            case HOURS:
+                dt = dt.withMinuteOfHour(0);
+            case MINUTES:
+                dt = dt.withSecondOfMinute(0);
+            case SECONDS:
+            default:
+                dt = dt.withMillisOfSecond(0);
+                break;
+        }
+        return dt.getMillis();
+    }
+
+    private DateTimeField timeUnitToTimeField(final TimeUnit timeUnit) {
+        final Chronology chronology = GregorianChronology.getInstance(_timeZone);
+        switch (timeUnit) {
+            case YEARS:
+                return chronology.year();
+            case MONTHS:
+                return chronology.monthOfYear();
+            case WEEKS:
+                return chronology.weekOfWeekyear();
+            case DAYS:
+                return chronology.dayOfMonth();
+            case HOURS:
+                return chronology.hourOfDay();
+            case MINUTES:
+                return chronology.minuteOfHour();
+            case SECONDS:
+                return chronology.secondOfDay();
+            default:
+                return chronology.millisOfSecond();
+        }
+    }
+
     private class MovingWindowDataPointGroup extends AggregatedDataPointGroupWrapper {
-        protected DateTimeField _unitField;
-        protected ConcurrentSkipListMap<Long, DataPoint> _dpBuffer;
-        protected Iterator<DataPoint> _dpIterator = null;
-        protected long _currentRangeTime;
+        private DateTimeField _unitField;
+        private final LinkedList<DataPoint> _dpBuffer;
+        private int _currentIndex;
+        private int _lastTruncatedIndex;
+        private TreeMap<Long, Integer> _timestampIndexMap;
+        private Iterator<DataPoint> _dpIterator;
+        private long _currentStartRange;
+        private long _currentEndRange;
 
         MovingWindowDataPointGroup(final DataPointGroup dataPointGroup) {
             super(dataPointGroup);
-            _dpBuffer = new ConcurrentSkipListMap<>();
-            _dpIterator = _dpBuffer.values().iterator();
-
-            final Chronology chronology = GregorianChronology.getInstance(_timeZone);
-
-            final TimeUnit tu = m_sampling.getUnit();
-            switch (tu) {
-            case YEARS:
-                _unitField = chronology.year();
-                break;
-            case MONTHS:
-                _unitField = chronology.monthOfYear();
-                break;
-            case WEEKS:
-                _unitField = chronology.weekOfWeekyear();
-                break;
-            case DAYS:
-                _unitField = chronology.dayOfMonth();
-                break;
-            case HOURS:
-                _unitField = chronology.hourOfDay();
-                break;
-            case MINUTES:
-                _unitField = chronology.minuteOfHour();
-                break;
-            case SECONDS:
-                _unitField = chronology.secondOfDay();
-                break;
-            default:
-                _unitField = chronology.millisOfSecond();
-                break;
-            }
+            _dpBuffer = new LinkedList<>();
+            _dpIterator = _dpBuffer.iterator();
+            _currentIndex = 0;
+            _lastTruncatedIndex = 0;
+            _timestampIndexMap = new TreeMap<>();
+            _unitField = timeUnitToTimeField(m_sampling.getUnit());
         }
 
         protected long getStartRange(final long timestamp) {
@@ -193,35 +213,54 @@ public class MovingWindowAggregator extends RangeAggregator {
 
                 // We calculate start and end ranges as the ranges may not be
                 // consecutive if data does not show up in each range.
-                final long startRange; 
-
                 if (_dpBuffer.isEmpty()) {
-                    // This is the first datapoint so front-load the sample window amount of data.
-                    startRange = _startTime;
+                    // Get the greater of the start values given we may not have datapoints for the
+                    // beginning of the range and we want the current datapoint to fit in the first
+                    // time range
+                    final long mwStartTime = calculateEarliestStartTime(_startTime);
+                    final long dpStartRange = getStartRange(currentDataPoint.getTimestamp());
+                    _currentStartRange = mwStartTime > dpStartRange ? mwStartTime : dpStartRange;
                 } else {
-                    startRange = getStartRange(currentDataPoint.getTimestamp());
+                    // Move the window forward one unit
+                    _currentStartRange = _unitField.add(_currentStartRange, 1);
+
+                    // Trim off any data that is too old
+                    final Map.Entry<Long, Integer> floorEntry = _timestampIndexMap.floorEntry(_currentStartRange);
+                    if (floorEntry != null) {
+                        _dpBuffer.subList(0, floorEntry.getValue() - _lastTruncatedIndex + 1).clear();
+                        _lastTruncatedIndex = floorEntry.getValue() + 1;
+                        _timestampIndexMap.headMap(floorEntry.getKey(), true).clear();
+                    }
+
+                    if (_dpBuffer.isEmpty()) {
+                        // We have no datapoints in the current window so we need to jump the window
+                        // forward to include the next available datapoint
+                        _currentStartRange = getStartRange(currentDataPoint.getTimestamp());
+                    }
                 }
-
-                final long endRange = _unitField.add(startRange, m_sampling.getValue());
-                _currentRangeTime = endRange;
-
-                // Trim off any data that is too old
-                _dpBuffer = new ConcurrentSkipListMap<>(_dpBuffer.tailMap(startRange, false));
+                _currentEndRange = _unitField.add(_currentStartRange, m_sampling.getValue());
 
                 // Add data up until the end of the range
-                while (currentDataPoint != null && currentDataPoint.getTimestamp() <= endRange) {
-                    if (currentDataPoint.getTimestamp() > startRange) {
-                        _dpBuffer.put(currentDataPoint.getTimestamp(), currentDataPoint);
+                while (currentDataPoint != null && currentDataPoint.getTimestamp() <= _currentEndRange) {
+                    if (currentDataPoint.getTimestamp() > _currentStartRange) {
+                        _timestampIndexMap.put(currentDataPoint.getTimestamp(), _currentIndex++);
+                        _dpBuffer.add(currentDataPoint);
                     }
                     if (hasNextInternal()) {
                         currentDataPoint = nextInternal();
                     }
                 }
 
-                _dpIterator = _dpBuffer.values().iterator();
+                _dpIterator = _dpBuffer.iterator();
             }
 
-            return new DataPointWrapper(_currentRangeTime, _dpIterator.next());
+
+            final DataPoint next = _dpIterator.next();
+            if (next instanceof HistogramDataPoint) {
+                return new HistogramDataPointWrapper(_currentEndRange, (HistogramDataPoint) next);
+            } else {
+                return new DataPointWrapper(_currentEndRange, next);
+            }
         }
 
         @Override
@@ -234,8 +273,8 @@ public class MovingWindowAggregator extends RangeAggregator {
      * Class to wrap a Datapoint so that the timestamp can be masked and overwritten.
      */
     protected static class DataPointWrapper implements DataPoint {
-        protected DataPoint _wrappedDataPoint;
-        protected long _timestamp;
+        private DataPoint _wrappedDataPoint;
+        private long _timestamp;
 
         DataPointWrapper(final long timestamp, final DataPoint dataPoint) {
             _timestamp = timestamp;
@@ -295,6 +334,99 @@ public class MovingWindowAggregator extends RangeAggregator {
         @Override
         public void setDataPointGroup(final DataPointGroup dataPointGroup) {
             _wrappedDataPoint.setDataPointGroup(dataPointGroup);
+        }
+    }
+
+    /**
+     * Class to wrap a Datapoint so that the timestamp can be masked and overwritten.
+     */
+    protected static class HistogramDataPointWrapper implements HistogramDataPoint {
+        private HistogramDataPoint _wrappedDataPoint;
+        private long _timestamp;
+
+        HistogramDataPointWrapper(final long timestamp, final HistogramDataPoint dataPoint) {
+            _timestamp = timestamp;
+            _wrappedDataPoint = dataPoint;
+        }
+
+        @Override
+        public long getTimestamp() {
+            return _timestamp;
+        }
+
+        @Override
+        public void writeValueToBuffer(final DataOutput buffer) throws IOException {
+            _wrappedDataPoint.writeValueToBuffer(buffer);
+        }
+
+        @Override
+        public void writeValueToJson(final JSONWriter writer) throws JSONException {
+            _wrappedDataPoint.writeValueToJson(writer);
+        }
+
+        @Override
+        public String getApiDataType() {
+            return _wrappedDataPoint.getApiDataType();
+        }
+
+        @Override
+        public String getDataStoreDataType() {
+            return _wrappedDataPoint.getDataStoreDataType();
+        }
+
+        @Override
+        public boolean isLong() {
+            return _wrappedDataPoint.isLong();
+        }
+
+        @Override
+        public long getLongValue() {
+            return _wrappedDataPoint.getLongValue();
+        }
+
+        @Override
+        public boolean isDouble() {
+            return _wrappedDataPoint.isDouble();
+        }
+
+        @Override
+        public double getDoubleValue() {
+            return _wrappedDataPoint.getDoubleValue();
+        }
+
+        @Override
+        public DataPointGroup getDataPointGroup() {
+            return _wrappedDataPoint.getDataPointGroup();
+        }
+
+        @Override
+        public void setDataPointGroup(final DataPointGroup dataPointGroup) {
+            _wrappedDataPoint.setDataPointGroup(dataPointGroup);
+        }
+
+        @Override
+        public int getSampleCount() {
+            return _wrappedDataPoint.getSampleCount();
+        }
+
+        @Override
+        public double getSum() {
+            return _wrappedDataPoint.getSum();
+        }
+
+        @Override
+        public double getMin() {
+            return _wrappedDataPoint.getMin();
+        }
+
+        @Override
+        public double getMax() {
+            return _wrappedDataPoint.getMax();
+        }
+
+        @Override
+        public TreeMap<Double, Integer> getMap() {
+            return _wrappedDataPoint.getMap();
         }
     }
 }

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregator.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 
 /**
@@ -425,7 +426,7 @@ public class MovingWindowAggregator extends RangeAggregator {
         }
 
         @Override
-        public TreeMap<Double, Integer> getMap() {
+        public NavigableMap<Double, Integer> getMap() {
             return _wrappedDataPoint.getMap();
         }
     }

--- a/src/main/java/com/arpnetworking/kairosdb/processors/MovingWindowQueryPreProcessor.java
+++ b/src/main/java/com/arpnetworking/kairosdb/processors/MovingWindowQueryPreProcessor.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2018 Dropbox Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.kairosdb.processors;
+
+import com.arpnetworking.kairosdb.aggregators.MovingWindowAggregator;
+import org.kairosdb.core.datastore.QueryMetric;
+import org.kairosdb.core.http.rest.json.Query;
+import org.kairosdb.plugin.Aggregator;
+import org.kairosdb.plugin.QueryPreProcessor;
+
+/**
+ * KairosDB QueryPreProcessor that modifies the start time for queries that contain a
+ * movingWindow aggregator.  In the case of a movingWindow aggregator the query needs to fetch a
+ * windows width worth of data before the specified start time.  By doing this downstream aggregators
+ * will be provided with a complete set of datapoints for the first window width of the requested range.
+ *
+ * @author Gil Markham (gmarkham at dropbox dot com)
+ */
+public class MovingWindowQueryPreProcessor implements QueryPreProcessor {
+    @Override
+    public Query preProcessQuery(final Query query) {
+        for (QueryMetric queryMetric: query.getQueryMetrics()) {
+            final long originalStartTime = queryMetric.getStartTime();
+            for (Aggregator aggregator : queryMetric.getAggregators()) {
+                if (aggregator instanceof MovingWindowAggregator) {
+                    final MovingWindowAggregator mwAgg = (MovingWindowAggregator) aggregator;
+                    final long mwStartTime = mwAgg.calculateEarliestStartTime(originalStartTime);
+                    if (mwStartTime < queryMetric.getStartTime()) {
+                        queryMetric.setStartTime(mwStartTime);
+                    }
+                }
+            }
+        }
+        return query;
+    }
+}

--- a/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
+++ b/src/test/java/com/arpnetworking/kairosdb/aggregators/MovingWindowAggregatorTest.java
@@ -72,6 +72,16 @@ public class MovingWindowAggregatorTest {
         final Iterator<Map.Entry<Long, Long>> entryIter = dpCountMap.entrySet().iterator();
         Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
         Map.Entry<Long, Long> nextEntry = entryIter.next();
+        Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 2, 1, 0, 0, utc)));
+        Assert.assertThat(nextEntry.getValue(), Matchers.is(31L)); // 31
+
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+        nextEntry = entryIter.next();
+        Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 3, 1, 0, 0, utc)));
+        Assert.assertThat(nextEntry.getValue(), Matchers.is(59L)); // 31 + 28
+
+        Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
+        nextEntry = entryIter.next();
         Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2014, 4, 1, 0, 0, utc)));
         Assert.assertThat(nextEntry.getValue(), Matchers.is(90L)); // 31 + 28 + 31
 
@@ -125,11 +135,11 @@ public class MovingWindowAggregatorTest {
         }
 
         final Iterator<Map.Entry<Long, Long>> entryIter = dpCountMap.entrySet().iterator();
-        for (int i = 8; i <= 30; i++) {
+        for (int i = 2; i <= 30; i++) {
             Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
             final Map.Entry<Long, Long> nextEntry = entryIter.next();
             Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2018, 1, i, 0, 0, utc)));
-            Assert.assertThat(nextEntry.getValue(), Matchers.is(7L));
+            Assert.assertThat(nextEntry.getValue(), Matchers.is(i < 8 ? i - 1 : 7L));
         }
     }
 
@@ -165,11 +175,11 @@ public class MovingWindowAggregatorTest {
         }
 
         final Iterator<Map.Entry<Long, Long>> entryIter = dpCountMap.entrySet().iterator();
-        for (int i = 8; i <= 29; i++) {
+        for (int i = 1; i <= 29; i++) {
             Assert.assertThat(entryIter.hasNext(), Matchers.is(true));
             final Map.Entry<Long, Long> nextEntry = entryIter.next();
             Assert.assertThat(new DateTime(nextEntry.getKey(), utc), Matchers.is(new DateTime(2018, 1, i, 1, 1, utc)));
-            Assert.assertThat(nextEntry.getValue(), Matchers.is(7L));
+            Assert.assertThat(nextEntry.getValue(), Matchers.is(i < 7 ? i : 7L));
         }
     }
 }


### PR DESCRIPTION
Previous code didn't register the movingWindow aggregator with Kairosdb.  

Fixed issues with histogram data needing to be special cased as the base DataPoint representation isn't flexible enough.  Also added a QueryPreProcessor that moves the startTime forward by one window width for any queries that contain a movingWindow aggregator.