### PR TITLE
make integration tests less likely to reuse metric names from previous runs

### DIFF
--- a/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
+++ b/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.UUID;
 
 /**
  * Tests for storing histogram datapoints.
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Brandon Arp (brandon dot arp at smartsheet dot com)
  */
 public class AggregationIT {
-    private static final AtomicInteger TEST_NUMBER = new AtomicInteger(1);
     private static final List<Histogram> SINGLE_HIST_TEST_DATA = Lists.newArrayList(
             new Histogram(Arrays.asList(1d, 3d, 5d, 7d, 9d, 1d, 9d, 1d, 9d)));
     private static final List<Double> DOUBLE_TEST_DATA = Arrays.asList(1d, 3d, 5d, 7d, 9d, 1d, 9d, 1d, 9d);
@@ -277,7 +276,7 @@ public class AggregationIT {
             final double expected,
             final Map<String, ?> aggParams)
             throws JSONException, IOException {
-        final String metricName = aggregator + "_agg_test_" + TEST_NUMBER.getAndIncrement();
+        final String metricName = newMetricName(aggregator);
 
         int i = 1;
         for (final Double number : data) {
@@ -294,7 +293,7 @@ public class AggregationIT {
             final double expected,
             final Map<String, ?> aggParams)
         throws JSONException, IOException {
-        final String metricName = aggregator + "_agg_test_" + TEST_NUMBER.getAndIncrement();
+        final String metricName = newMetricName(aggregator);
 
         int i = 1;
         for (final Histogram histogram : histograms) {
@@ -311,7 +310,7 @@ public class AggregationIT {
             final Histogram expected,
             final Map<String, ?> aggParams)
             throws JSONException, IOException {
-        final String metricName = aggregator + "_agg_test_" + TEST_NUMBER.getAndIncrement();
+        final String metricName = newMetricName(aggregator);
 
         int i = 1;
         for (final Histogram histogram : histograms) {
@@ -377,6 +376,10 @@ public class AggregationIT {
         try (CloseableHttpResponse response = _client.execute(post)) {
             Assert.assertEquals(expectedCode, response.getStatusLine().getStatusCode());
         }
+    }
+
+    private static String newMetricName(final String prefix) {
+        return prefix + "_test_" + UUID.randomUUID();
     }
 
     private String queryWithExpectedCode(


### PR DESCRIPTION
Joey was hitting integration test flakiness due to KairosDB (somehow? despite being freshly restarted and configured to use H2?) remembering data from previous test-runs. And there's no obvious downside to enthusiastically randomizing metric-names, so... let's do that?