### PR TITLE
Nan fix

### DIFF
--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/DelegatingFilterAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/DelegatingFilterAggregator.java
@@ -33,10 +33,10 @@ import javax.inject.Named;
         description = "Filters datapoints according to filter operation with a null data point.")
 public class DelegatingFilterAggregator extends DelegatingAggregator {
     private FilterAggregator.FilterOperation _filterop
-            = FilterAggregator.FilterOperation.LT;
+            = FilterAggregator.FilterOperation.EQUAL;
     private HistogramFilterAggregator.FilterIndeterminate _filterinc
             = HistogramFilterAggregator.FilterIndeterminate.KEEP;
-    private double _threshold;
+    private double _threshold = 0.0;
 
     /**
      * Setter for filter operation.

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/DelegatingFilterAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/DelegatingFilterAggregator.java
@@ -32,8 +32,10 @@ import javax.inject.Named;
         name = "filter",
         description = "Filters datapoints according to filter operation with a null data point.")
 public class DelegatingFilterAggregator extends DelegatingAggregator {
-    private FilterAggregator.FilterOperation _filterop;
-    private HistogramFilterAggregator.FilterIndeterminate _filterinc;
+    private FilterAggregator.FilterOperation _filterop
+            = FilterAggregator.FilterOperation.LT;
+    private HistogramFilterAggregator.FilterIndeterminate _filterinc
+            = HistogramFilterAggregator.FilterIndeterminate.KEEP;
     private double _threshold;
 
     /**

--- a/src/main/java/com/arpnetworking/kairosdb/aggregators/HistogramFilterAggregator.java
+++ b/src/main/java/com/arpnetworking/kairosdb/aggregators/HistogramFilterAggregator.java
@@ -75,7 +75,7 @@ public class HistogramFilterAggregator implements Aggregator {
             description = "The operation performed for each data point.",
             type = "enum",
             options = {"lte", "lt", "gte", "gt", "equal"},
-            default_value = "lt"
+            default_value = "equal"
     )
     private FilterAggregator.FilterOperation _filterop;
 
@@ -103,7 +103,7 @@ public class HistogramFilterAggregator implements Aggregator {
     @Inject
     public HistogramFilterAggregator() {
         _threshold = 0.0;
-        _filterop = FilterAggregator.FilterOperation.LT;
+        _filterop = FilterAggregator.FilterOperation.EQUAL;
         _filterinc = FilterIndeterminate.KEEP;
     }
 

--- a/src/test/java/com/arpnetworking/kairosdb/aggregators/HistogramFilterAggregatorTest.java
+++ b/src/test/java/com/arpnetworking/kairosdb/aggregators/HistogramFilterAggregatorTest.java
@@ -67,8 +67,8 @@ public class HistogramFilterAggregatorTest {
             Assert.assertTrue("Actual group is missing data points", actual.hasNext());
             final DataPoint act = actual.next();
             final DataPoint exp = expected.next();
-            Assert.assertEquals("Expected and actual timestamps do not match", act.getTimestamp(),
-                    exp.getTimestamp());
+            Assert.assertEquals("Expected and actual timestamps do not match", exp.getTimestamp(),
+                    act.getTimestamp());
             assertHistogramsEqual(exp, act);
         }
         Assert.assertFalse("Actual group has too many data points", actual.hasNext());
@@ -193,12 +193,7 @@ public class HistogramFilterAggregatorTest {
                 new DoubleDataPoint(2L, 100.0)
         );
 
-        final ListDataPointGroup expected = createGroup(
-                new HistogramDataPointImpl(1L, 7, new TreeMap<>(),
-                        Double.NaN, Double.NaN, Double.NaN, Double.NaN),
-                new HistogramDataPointImpl(2L, 7, new TreeMap<>(),
-                        Double.NaN, Double.NaN, Double.NaN, Double.NaN)
-        );
+        final ListDataPointGroup expected = createGroup();
 
         final DataPointGroup results = _aggregator.aggregate(group);
         assertGroupsEqual(expected, results);
@@ -206,16 +201,14 @@ public class HistogramFilterAggregatorTest {
 
     @Test
     public void testFilterRemoveAllBins() {
-        final ListDataPointGroup group = createGroup(createHistogram(1L, POS_100_0, POS_512_0, POS_516_0));
+        final ListDataPointGroup group = createGroup(createHistogram(1L, POS_100_0, POS_512_0, POS_516_0),
+                createHistogram(2L, POS_100_0, POS_512_0, POS_516_0));
 
         _aggregator.setFilterOp(FilterAggregator.FilterOperation.GTE);
         _aggregator.setFilterIndeterminateInclusion(HistogramFilterAggregator.FilterIndeterminate.KEEP);
         _aggregator.setThreshold(POS_0_0);
 
-        final ListDataPointGroup expected = createGroup(
-                new HistogramDataPointImpl(1L, 7, new TreeMap<>(),
-                        Double.NaN, Double.NaN, Double.NaN, Double.NaN)
-        );
+        final ListDataPointGroup expected = createGroup();
         final DataPointGroup results = _aggregator.aggregate(group);
         assertGroupsEqual(expected, results);
     }

--- a/src/test/java/com/arpnetworking/kairosdb/aggregators/HistogramPercentRemainingAggregatorTest.java
+++ b/src/test/java/com/arpnetworking/kairosdb/aggregators/HistogramPercentRemainingAggregatorTest.java
@@ -76,7 +76,7 @@ public class HistogramPercentRemainingAggregatorTest {
 
     @Test
     public void testPercentRemainingEmptyGroup() {
-        runPercentRemainingTest(EMPTY_HIST_GROUP, createDoubleGroup(-1d), _filterAggregator);
+        runPercentRemainingTest(EMPTY_HIST_GROUP, createDoubleGroup(-1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -90,7 +90,7 @@ public class HistogramPercentRemainingAggregatorTest {
     @Test
     public void testPercentRemainingFilterAllOut() {
         configureFilter(FilterAggregator.FilterOperation.GT, 0d);
-        runPercentRemainingTest(SINGLE_HIST_GROUP, createDoubleGroup(0d), _filterAggregator);
+        runPercentRemainingTest(SINGLE_HIST_GROUP, createDoubleGroup(), _filterAggregator);
     }
 
     @Test

--- a/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
+++ b/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
@@ -260,6 +260,13 @@ public class AggregationIT {
     }
 
     @Test
+    public void testFilterAggregatorMissingIndeterminateField() throws IOException, JSONException {
+        final List<Histogram> expected = Lists.newArrayList(
+                new Histogram(Arrays.asList(5d, 7d, 9d, 9d, 9d)));
+        testAggregate("filter", SINGLE_HIST_TEST_DATA, expected, filterParam("lt", 5d));
+    }
+
+    @Test
     public void testFilterAroundZero() throws IOException, JSONException {
         final List<Histogram> input = Lists.newArrayList(new Histogram(Arrays.asList(100d, 0d, -0d, -110d)));
         final List<Histogram> expectedPositiveBins = Lists.newArrayList(new Histogram(Arrays.asList(100d, 0d)));

--- a/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
+++ b/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
@@ -276,6 +276,13 @@ public class AggregationIT {
     }
 
     @Test
+    public void testFilterAll() throws IOException, JSONException {
+        final List<Histogram> expected = Lists.newArrayList(
+                new Histogram(Collections.emptyList()));
+        testAggregate("filter", SINGLE_HIST_TEST_DATA, expected, filterParam("gt", 0));
+    }
+
+    @Test
     public void testDefaultFilterAggregator() throws IOException, JSONException {
         final List<Double> input = Arrays.asList(9d, 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d);
         final List<Double> expected = Arrays.asList(9d, 8d, 7d, 6d, 5d);

--- a/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
+++ b/src/test/java/com/arpnetworking/kairosdb/integration/AggregationIT.java
@@ -277,9 +277,8 @@ public class AggregationIT {
 
     @Test
     public void testFilterAll() throws IOException, JSONException {
-        final List<Histogram> expected = Lists.newArrayList(
-                new Histogram(Collections.emptyList()));
-        testAggregate("filter", SINGLE_HIST_TEST_DATA, expected, filterParam("gt", 0));
+        testAggregate("filter", SINGLE_HIST_TEST_DATA, Collections.emptyList(),
+                filterParam("gt", 0));
     }
 
     @Test
@@ -287,6 +286,13 @@ public class AggregationIT {
         final List<Double> input = Arrays.asList(9d, 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d);
         final List<Double> expected = Arrays.asList(9d, 8d, 7d, 6d, 5d);
         testDoubleAggregate("filter", input, expected, filterParam("lt", 5d));
+    }
+
+    @Test
+    public void testDefaultFilterAggregatorWithIndeterminateField() throws IOException, JSONException {
+        final List<Double> input = Arrays.asList(9d, 8d, 7d, 6d, 5d, 4d, 3d, 2d, 1d);
+        final List<Double> expected = Arrays.asList(9d, 8d, 7d, 6d, 5d);
+        testDoubleAggregate("filter", input, expected, filterParam("lt", "keep", 5d));
     }
 
     // **** percent remaining aggregator ***
@@ -307,7 +313,7 @@ public class AggregationIT {
     @Test
     public void testPercentRemainingAggregatorFilterAll() throws IOException, JSONException {
         testAggregateToDoubles(
-                MULTI_HIST_TEST_DATA, Lists.newArrayList(0d, 0d),
+                MULTI_HIST_TEST_DATA, Collections.emptyList(),
                 new AggregatorAndParams("filter", filterParam("gt", "keep", 0d)),
                 new AggregatorAndParams("percent_remaining", Collections.emptyMap())
         );
@@ -483,7 +489,8 @@ public class AggregationIT {
             postHistogramWithExpectedCode(metricName, i++, histogram, 204);
         }
 
-        final String body = queryWithExpectedCode(metricName, 1000 + histograms.size(), aggregator, aggParams, 200);
+        final String body = queryWithExpectedCode(metricName, 1000 + histograms.size(), aggregator,
+                aggParams, 200);
         verifyQueryResponse(histograms.size(), expected, body);
     }
 
@@ -500,7 +507,8 @@ public class AggregationIT {
             postHistogramWithExpectedCode(metricName, i++, histogram, 204);
         }
 
-        final String body = queryWithExpectedCode(metricName, 1000 + histograms.size(), aggregator, aggParams, 200);
+        final String body = queryWithExpectedCode(metricName, 1000 + histograms.size(), aggregator,
+                aggParams, 200);
         verifyQueryResponse(histograms.size(), expected, body);
     }
 
@@ -585,12 +593,11 @@ public class AggregationIT {
         final JSONArray result = queryObject.getJSONArray("results")
                 .getJSONObject(0).getJSONArray("values");
 
-        Assert.assertEquals(result.length(), expectedResult.size());
+        Assert.assertEquals(expectedResult.size(), result.length());
         for (int i = 0; i < result.length(); i++) {
             final JSONArray jsonPair = result.getJSONArray(i);
             Assert.assertEquals(i + 1, jsonPair.getInt(0));
-            final Double actual = jsonPair.getDouble(1);
-
+            final double actual = jsonPair.getDouble(1);
             Assert.assertEquals(expectedResult.get(i), actual, 0.000001);
         }
     }


### PR DESCRIPTION
NaN values cannot be serialized into JSON so histograms that get all their values filtered out will simply be skipped as datapoints to prevent their min,max,mean from being serialized